### PR TITLE
Adding support for message URI on OSX

### DIFF
--- a/taskopen
+++ b/taskopen
@@ -30,9 +30,15 @@
 BROWSER=firefox
 EDITOR=vim
 TASKBIN=task
-XDG=xdg-open
 
-FILEREGEX="/^(\/|www|http|\.|~|Message-ID:)/"
+if [[ $OSTYPE =~ .*darwin.* ]] #OSX
+then
+   XDG=open
+else 
+   XDG=xdg-open
+fi
+
+FILEREGEX="/^(\/|www|http|\.|~|Message-ID:|message:)/"
 
 if [ $# != 1 ]; then
 	echo "Usage: $0 <id>"


### PR DESCRIPTION
I've added to fileregex the message URI which is supported in OSX 10.5.
This allows Mac users to taskopen their messages from their mail client
(e.g. Mail.app).  I've also added a check to see if we're on OSX, if so
use open, since xdg doesn't come standard.

---

I'm a big fan of taskopen! I'm planning to write a brief blog post about how I annotate my tasks with email messages, and how I use taskopen to drive it (which includes my minor change to your script). I hope others find it useful. Cheers!
