### PR TITLE
Allow path with spaces in note command creation

### DIFF
--- a/scripts/editnote
+++ b/scripts/editnote
@@ -3,10 +3,10 @@
 
 # Usage
 if [ $# -eq 3 ]; then
-	if [ ! -e $1 ]; then
-		echo "* [ ] $2  #$3" > $1
+	if [ ! -e "$1" ]; then
+		echo "* [ ] $2  #$3" > "$1"
 	fi
-	$EDITOR $1
+	$EDITOR "$1"
 else
 	echo "Usage: $0 <file-path> <description> <uuid>"
 fi


### PR DESCRIPTION
This PR allows the use of this kind of configuration

`notes.command="""editnote "~/Mobile Documents/taskwarrior_notes/$UUID$LAST_MATCH" "$TASK_DESCRIPTION" $UUID"""`