### PR TITLE
Replace stdlib re with pure-Nim regex package

### DIFF
--- a/src/config.nim
+++ b/src/config.nim
@@ -9,7 +9,7 @@ import tables
 import os
 import parsecfg
 import streams
-import re
+import regex
 import strutils
 import ./types
 import ./output
@@ -107,9 +107,10 @@ proc parseFile(filepath: string, settings: var Settings) =
             warn.log("Invalid config option in [General]: ", e.key, ": ", e.value)
 
         of "Actions":
-          if e.key =~ re"(.*)\.(target|regex|labelregex|command|modes|filtercommand|inlinecommand)":
-            let actname  = matches[0]
-            let actfield = matches[1]
+          var m = RegexMatch2()
+          if e.key.match(re2"(.*)\.(target|regex|labelregex|command|modes|filtercommand|inlinecommand)", m):
+            let actname  = e.key[m.group(0)]
+            let actfield = e.key[m.group(1)]
             if not settings.validActions.hasKey(actname):
               settings.validActions[actname] = Action(name: actname,
                                                       target: "annotations",
@@ -122,11 +123,12 @@ proc parseFile(filepath: string, settings: var Settings) =
             warn.log("Invalid config option in [Actions]: ", e.key, ": ", e.value)
 
         of "CLI":
+          var m = RegexMatch2()
           if e.key == "default":
             settings.defaultSubcommand = e.value
-          elif e.key =~ re"(alias|group)\.([^\.]*)":
-            let name = matches[1]
-            case matches[0]
+          elif e.key.match(re2"(alias|group)\.([^\.]*)", m):
+            let name = e.key[m.group(1)]
+            case e.key[m.group(0)]
             of "alias":
               settings.validSubcommands[name] = e.value
             of "group":

--- a/src/core.nim
+++ b/src/core.nim
@@ -6,7 +6,7 @@
 #
 
 import os
-import re
+import regex
 import strutils
 import tables
 import strtabs
@@ -61,13 +61,14 @@ iterator match_actions_label(
   var env = copyEnv(baseenv)
   for act in actions:
     # split in label and file part
-    let splitre = re"((\S+):\s+)?(.*)"
-    if text =~ splitre:
-      let label = matches[1]
-      let file  = matches[2]
+    let splitre = re2"((\S+):\s+)?(.*)"
+    var sm = RegexMatch2()
+    if text.match(splitre, sm):
+      let label = text[sm.group(1)]
+      let file  = text[sm.group(2)]
 
-      let labelregex = re(act.labelregex)
-      let fileregex  = re(act.regex)
+      let labelregex = re2(act.labelregex)
+      let fileregex  = re2(act.regex)
 
       # skip action if label does not match
       if not label.match(labelregex):
@@ -75,12 +76,13 @@ iterator match_actions_label(
 
       # skip action if file does not match
       env["LAST_MATCH"] = ""
-      if file =~ fileregex:
-        for m in matches:
-          if len(m) == 0:
+      var fm = RegexMatch2()
+      if file.match(fileregex, fm):
+        for i in 0..<fm.groupsCount:
+          let cap = file[fm.group(i)]
+          if cap.len == 0:
             break
-          else:
-            env["LAST_MATCH"] = m
+          env["LAST_MATCH"] = cap
       else:
         continue
 
@@ -115,14 +117,15 @@ iterator match_actions_pure(
 
   var env = copyEnv(baseenv)
   for act in actions:
-    let fileregex  = re(act.regex)
-    if text =~ fileregex:
+    let fileregex  = re2(act.regex)
+    var fm = RegexMatch2()
+    if text.match(fileregex, fm):
       env["LAST_MATCH"] = ""
-      for m in matches:
-        if len(m) == 0:
+      for i in 0..<fm.groupsCount:
+        let cap = text[fm.group(i)]
+        if cap.len == 0:
           break
-        else:
-          env["LAST_MATCH"] = m
+        env["LAST_MATCH"] = cap
     else:
       continue
 
@@ -208,9 +211,10 @@ proc find_actionable_items(
 
 proc sortkeys(sortstr: string): seq[tuple[key: string, desc: bool]] =
   for field in sortstr.split(','):
-    if field =~ re"(.*?)(\+|-)?$":
-      let key  = matches[0]
-      let desc = matches[1] == "-"
+    var sm = RegexMatch2()
+    if field.match(re2"(.*?)(\+|-)?$", sm):
+      let key  = field[sm.group(0)]
+      let desc = field[sm.group(1)] == "-"
       result.add((key: key, desc: desc))
 
 

--- a/src/output.nim
+++ b/src/output.nim
@@ -8,7 +8,7 @@
 import terminal
 import tables
 import json
-import re
+import regex
 from strutils import split, parseInt, spaces, center, strip
 from unicode import runeLen, runeSubStr, alignLeft, align
 import ./types
@@ -154,9 +154,10 @@ proc menu*(items: openArray[Actionable]): seq[int] =
   let answer = readLine(stdin)
   let maxid  = len(items)
   for ids in answer.split():
-    if ids =~ re"(\d+)(?:\.\.|-)(\d+)":
-      let fromid = parseInt(matches[0])
-      let toid   = parseInt(matches[1])
+    var m = RegexMatch2()
+    if ids.match(re2"(\d+)(?:\.\.|-)(\d+)", m):
+      let fromid = parseInt(ids[m.group(0)])
+      let toid   = parseInt(ids[m.group(1)])
       if fromid < 1 or fromid > maxid:
         error.log(fromid, " is an invalid number")
         quit(1)
@@ -168,7 +169,7 @@ proc menu*(items: openArray[Actionable]): seq[int] =
         quit(1)
       for id in fromid..toid:
         result.add(id-1)
-    elif ids =~ re"\d+":
+    elif ids.match(re2"\d+"):
       let id = parseInt(ids)
       if id < 1 or id > maxid:
         error.log(id, " is an invalid number")

--- a/src/taskwarrior.nim
+++ b/src/taskwarrior.nim
@@ -7,7 +7,7 @@
 
 import osproc
 import strutils
-import re
+import regex
 import json
 import ./output
 
@@ -30,10 +30,11 @@ proc current_context*(taskbin: string, taskargs: openArray[string]): string =
   let args = @default_args & @taskargs & @["context", "show"]
   exec(taskbin, args, result)
   for line in splitLines(result):
-    if line =~ re".*with filter '(.*)' is currently applied.$":
-      return "\\(" & matches[0] & "\\)"
-    elif line =~ re".*read filter: '(.*)'$":
-      return "\\(" & matches[0] & "\\)"
+    var m = RegexMatch2()
+    if line.match(re2".*with filter '(.*)' is currently applied\.$", m):
+      return "\\(" & line[m.group(0)] & "\\)"
+    elif line.match(re2".*read filter: '(.*)'$", m):
+      return "\\(" & line[m.group(0)] & "\\)"
   return ""
 
 proc json*(taskbin: string, taskargs: openArray[string], filter: openArray[string]): JsonNode =

--- a/taskopen.nimble
+++ b/taskopen.nimble
@@ -13,6 +13,7 @@ bin         = @["taskopen"]
 # Deps
 
 requires "nim >= 1.4.0"
+requires "regex >= 0.19.0"
 
 # TODO add external dependency to taskwarrior
 


### PR DESCRIPTION
libpcre3, present up to Ubuntu 24.04 (Noble) [1], was dropped in Ubuntu 26.04 (Resolute) [2], causing the compiled binary to fail at runtime with:
  could not load: libpcre.so(.3|.1|)

Migrate all four source files from Nim's stdlib re module (which dynamically loads libpcre at runtime) to the regex nimble package [3] (pure Nim NFA engine, zero C dependencies). Update taskopen.nimble to declare the new dependency.

Note: I'm new to Nim, so this code may not be idiomatic.

[1] https://packages.ubuntu.com/noble/libpcre3
[2] https://packages.ubuntu.com/resolute/libpcre3
[3] https://github.com/nitely/nim-regex